### PR TITLE
Automatically create download page links

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@next/font": "13.2.3",
+    "@octokit/rest": "^19.0.7",
     "@rsuite/icons": "^1.0.2",
     "@types/node": "18.14.5",
     "@types/react": "18.0.28",

--- a/src/pages/downloads.tsx
+++ b/src/pages/downloads.tsx
@@ -10,10 +10,59 @@ import AppleIcon from '@rsuite/icons/legacy/Apple'
 import LinuxIcon from '@rsuite/icons/legacy/Linux'
 import { Icon } from '@rsuite/icons'
 import { BsClipboard } from 'react-icons/bs'
+import { GetStaticProps } from 'next'
+import { Octokit } from '@octokit/rest'
 
+const octokit = new Octokit()
 const inter = Inter({ subsets: ['latin'] })
 
-export default function Downloads() {
+type ReleaseData = {
+  url: string
+  name: string
+}
+
+type Props = {
+  release: {
+    windows: ReleaseData | null
+    macos: ReleaseData | null
+    appImage: ReleaseData | null
+    deb: ReleaseData | null
+  }
+}
+
+export const getStaticProps: GetStaticProps<Props> = async () => {
+  const {
+    data: { assets }
+  } = await octokit.repos.getLatestRelease({
+    owner: 'h3poteto',
+    repo: 'fedistar'
+  })
+
+  const assetPerPlatforms = {
+    windows: assets.find(asset => asset.name.includes('msi')),
+    macos: assets.find(asset => asset.name.includes('dmg')),
+    appImage: assets.find(asset => asset.name.includes('AppImage')),
+    deb: assets.find(asset => asset.name.includes('deb'))
+  }
+
+  return {
+    props: {
+      release: {
+        windows: assetPerPlatforms.windows
+          ? { url: assetPerPlatforms.windows.browser_download_url, name: assetPerPlatforms.windows.name }
+          : null,
+        macos: assetPerPlatforms.macos ? { url: assetPerPlatforms.macos.browser_download_url, name: assetPerPlatforms.macos.name } : null,
+        appImage: assetPerPlatforms.appImage
+          ? { url: assetPerPlatforms.appImage.browser_download_url, name: assetPerPlatforms.appImage.name }
+          : null,
+        deb: assetPerPlatforms.deb ? { url: assetPerPlatforms.deb.browser_download_url, name: assetPerPlatforms.deb.name } : null
+      }
+    },
+    revalidate: 60
+  }
+}
+
+export default function Downloads(props: Props) {
   const copyAUR = (text: string) => {
     navigator.clipboard.writeText(text)
   }
@@ -31,67 +80,69 @@ export default function Downloads() {
             </div>
             <div style={{ marginTop: '8vh' }}>
               <div className="downloads">
-                <div style={{ margin: '8px 0' }}>
-                  <h2 style={{ borderBottom: '1px solid var(--rs-divider-border)' }}>Windows</h2>
-                  <Button
-                    appearance="primary"
-                    href="https://github.com/h3poteto/fedistar/releases/download/v1.0.0/fedistar_1.0.0_x64_en-US.msi"
-                    startIcon={<WindowsIcon />}
-                  >
-                    Fedistar-1.0.0-x64.msi
-                  </Button>
-                </div>
-                <h2 style={{ borderBottom: '1px solid var(--rs-divider-border)' }}>MacOS</h2>
-                <div style={{ margin: '8px 0' }}>
-                  <Link href="https://apps.apple.com/us/app/fedistar/id6445863996" target="_blank" rel="noopener noreferrer">
-                    <Image src="/app-store.svg" alt="Download from Mac App Store" width={156} height={40} />
-                  </Link>
-                </div>
-                <div style={{ margin: '8px 0' }}>
-                  <Button
-                    appearance="primary"
-                    href="https://github.com/h3poteto/fedistar/releases/download/v1.0.0/fedistar_1.0.0_universal.dmg"
-                    startIcon={<AppleIcon />}
-                  >
-                    Fedistar-1.0.0-universal.dmg
-                  </Button>
-                </div>
-                <h2 style={{ borderBottom: '1px solid var(--rs-divider-border)' }}>Linux</h2>
-                <div style={{ margin: '8px 0' }}>
-                  <div
-                    style={{
-                      backgroundColor: 'var(--rs-gray-700)',
-                      width: '240px',
-                      padding: '8px 0 8px 12px',
-                      borderRadius: '4px',
-                      margin: '8px 0',
-                      display: 'flex',
-                      justifyContent: 'space-between',
-                      alignItems: 'center'
-                    }}
-                  >
-                    <span>$ yay -S fedistar-bin</span>
-                    <Button appearance="link" onClick={() => copyAUR('yay -S fedistar-bin')}>
-                      <Icon as={BsClipboard} />
+                {props.release.windows && (
+                  <div style={{ margin: '8px 0' }}>
+                    <h2 style={{ borderBottom: '1px solid var(--rs-divider-border)' }}>Windows</h2>
+                    <Button appearance="primary" href={props.release.windows.url} startIcon={<WindowsIcon />}>
+                      {props.release.windows.name}
                     </Button>
                   </div>
-                  <Button
-                    appearance="primary"
-                    href="https://github.com/h3poteto/fedistar/releases/download/v1.0.0/fedistar_1.0.0_amd64.AppImage"
-                    startIcon={<LinuxIcon />}
-                  >
-                    Fedistar-1.0.0-amd64.AppImage
-                  </Button>
-                </div>
-                <div style={{ margin: '8px 0' }}>
-                  <Button
-                    appearance="primary"
-                    href="https://github.com/h3poteto/fedistar/releases/download/v1.0.0/fedistar_1.0.0_amd64.deb"
-                    startIcon={<LinuxIcon />}
-                  >
-                    Fedistar-1.0.0-amd64.deb
-                  </Button>
-                </div>
+                )}
+
+                {props.release.macos && (
+                  <>
+                    <h2 style={{ borderBottom: '1px solid var(--rs-divider-border)' }}>MacOS</h2>
+                    <div style={{ margin: '8px 0' }}>
+                      <Link href="https://apps.apple.com/us/app/fedistar/id6445863996" target="_blank" rel="noopener noreferrer">
+                        <Image src="/app-store.svg" alt="Download from Mac App Store" width={156} height={40} />
+                      </Link>
+                    </div>
+                    <div style={{ margin: '8px 0' }}>
+                      <Button appearance="primary" href={props.release.macos.url} startIcon={<AppleIcon />}>
+                        {props.release.macos.name}
+                      </Button>
+                    </div>
+                  </>
+                )}
+
+                {(props.release.appImage || props.release.deb) && (
+                  <>
+                    <h2 style={{ borderBottom: '1px solid var(--rs-divider-border)' }}>Linux</h2>
+                    <div style={{ margin: '8px 0' }}>
+                      <div
+                        style={{
+                          backgroundColor: 'var(--rs-gray-700)',
+                          width: '240px',
+                          padding: '8px 0 8px 12px',
+                          borderRadius: '4px',
+                          margin: '8px 0',
+                          display: 'flex',
+                          justifyContent: 'space-between',
+                          alignItems: 'center'
+                        }}
+                      >
+                        <span>$ yay -S fedistar-bin</span>
+                        <Button appearance="link" onClick={() => copyAUR('yay -S fedistar-bin')}>
+                          <Icon as={BsClipboard} />
+                        </Button>
+                      </div>
+
+                      {props.release.appImage && (
+                        <Button appearance="primary" href={props.release.appImage.url} startIcon={<LinuxIcon />}>
+                          {props.release.appImage.name}
+                        </Button>
+                      )}
+                    </div>
+
+                    {props.release.deb && (
+                      <div style={{ margin: '8px 0' }}>
+                        <Button appearance="primary" href={props.release.deb.url} startIcon={<LinuxIcon />}>
+                          {props.release.deb.name}
+                        </Button>
+                      </div>
+                    )}
+                  </>
+                )}
               </div>
             </div>
           </Content>

--- a/yarn.lock
+++ b/yarn.lock
@@ -156,6 +156,107 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@octokit/auth-token@^3.0.0":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@octokit/auth-token/-/auth-token-3.0.3.tgz#ce7e48a3166731f26068d7a7a7996b5da58cbe0c"
+  integrity sha512-/aFM2M4HVDBT/jjDBa84sJniv1t9Gm/rLkalaz9htOm+L+8JMj1k9w0CkUdcxNyNxZPlTxKPVko+m1VlM58ZVA==
+  dependencies:
+    "@octokit/types" "^9.0.0"
+
+"@octokit/core@^4.1.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@octokit/core/-/core-4.2.0.tgz#8c253ba9605aca605bc46187c34fcccae6a96648"
+  integrity sha512-AgvDRUg3COpR82P7PBdGZF/NNqGmtMq2NiPqeSsDIeCfYFOZ9gddqWNQHnFdEUf+YwOj4aZYmJnlPp7OXmDIDg==
+  dependencies:
+    "@octokit/auth-token" "^3.0.0"
+    "@octokit/graphql" "^5.0.0"
+    "@octokit/request" "^6.0.0"
+    "@octokit/request-error" "^3.0.0"
+    "@octokit/types" "^9.0.0"
+    before-after-hook "^2.2.0"
+    universal-user-agent "^6.0.0"
+
+"@octokit/endpoint@^7.0.0":
+  version "7.0.5"
+  resolved "https://registry.yarnpkg.com/@octokit/endpoint/-/endpoint-7.0.5.tgz#2bb2a911c12c50f10014183f5d596ce30ac67dd1"
+  integrity sha512-LG4o4HMY1Xoaec87IqQ41TQ+glvIeTKqfjkCEmt5AIwDZJwQeVZFIEYXrYY6yLwK+pAScb9Gj4q+Nz2qSw1roA==
+  dependencies:
+    "@octokit/types" "^9.0.0"
+    is-plain-object "^5.0.0"
+    universal-user-agent "^6.0.0"
+
+"@octokit/graphql@^5.0.0":
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/@octokit/graphql/-/graphql-5.0.5.tgz#a4cb3ea73f83b861893a6370ee82abb36e81afd2"
+  integrity sha512-Qwfvh3xdqKtIznjX9lz2D458r7dJPP8l6r4GQkIdWQouZwHQK0mVT88uwiU2bdTU2OtT1uOlKpRciUWldpG0yQ==
+  dependencies:
+    "@octokit/request" "^6.0.0"
+    "@octokit/types" "^9.0.0"
+    universal-user-agent "^6.0.0"
+
+"@octokit/openapi-types@^16.0.0":
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-16.0.0.tgz#d92838a6cd9fb4639ca875ddb3437f1045cc625e"
+  integrity sha512-JbFWOqTJVLHZSUUoF4FzAZKYtqdxWu9Z5m2QQnOyEa04fOFljvyh7D3GYKbfuaSWisqehImiVIMG4eyJeP5VEA==
+
+"@octokit/plugin-paginate-rest@^6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-6.0.0.tgz#f34b5a7d9416019126042cd7d7b811e006c0d561"
+  integrity sha512-Sq5VU1PfT6/JyuXPyt04KZNVsFOSBaYOAq2QRZUwzVlI10KFvcbUo8lR258AAQL1Et60b0WuVik+zOWKLuDZxw==
+  dependencies:
+    "@octokit/types" "^9.0.0"
+
+"@octokit/plugin-request-log@^1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz#5e50ed7083a613816b1e4a28aeec5fb7f1462e85"
+  integrity sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==
+
+"@octokit/plugin-rest-endpoint-methods@^7.0.0":
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-7.0.1.tgz#f7ebe18144fd89460f98f35a587b056646e84502"
+  integrity sha512-pnCaLwZBudK5xCdrR823xHGNgqOzRnJ/mpC/76YPpNP7DybdsJtP7mdOwh+wYZxK5jqeQuhu59ogMI4NRlBUvA==
+  dependencies:
+    "@octokit/types" "^9.0.0"
+    deprecation "^2.3.1"
+
+"@octokit/request-error@^3.0.0":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@octokit/request-error/-/request-error-3.0.3.tgz#ef3dd08b8e964e53e55d471acfe00baa892b9c69"
+  integrity sha512-crqw3V5Iy2uOU5Np+8M/YexTlT8zxCfI+qu+LxUB7SZpje4Qmx3mub5DfEKSO8Ylyk0aogi6TYdf6kxzh2BguQ==
+  dependencies:
+    "@octokit/types" "^9.0.0"
+    deprecation "^2.0.0"
+    once "^1.4.0"
+
+"@octokit/request@^6.0.0":
+  version "6.2.3"
+  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-6.2.3.tgz#76d5d6d44da5c8d406620a4c285d280ae310bdb4"
+  integrity sha512-TNAodj5yNzrrZ/VxP+H5HiYaZep0H3GU0O7PaF+fhDrt8FPrnkei9Aal/txsN/1P7V3CPiThG0tIvpPDYUsyAA==
+  dependencies:
+    "@octokit/endpoint" "^7.0.0"
+    "@octokit/request-error" "^3.0.0"
+    "@octokit/types" "^9.0.0"
+    is-plain-object "^5.0.0"
+    node-fetch "^2.6.7"
+    universal-user-agent "^6.0.0"
+
+"@octokit/rest@^19.0.7":
+  version "19.0.7"
+  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-19.0.7.tgz#d2e21b4995ab96ae5bfae50b4969da7e04e0bb70"
+  integrity sha512-HRtSfjrWmWVNp2uAkEpQnuGMJsu/+dBr47dRc5QVgsCbnIc1+GFEaoKBWkYG+zjrsHpSqcAElMio+n10c0b5JA==
+  dependencies:
+    "@octokit/core" "^4.1.0"
+    "@octokit/plugin-paginate-rest" "^6.0.0"
+    "@octokit/plugin-request-log" "^1.0.4"
+    "@octokit/plugin-rest-endpoint-methods" "^7.0.0"
+
+"@octokit/types@^9.0.0":
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-9.0.0.tgz#6050db04ddf4188ec92d60e4da1a2ce0633ff635"
+  integrity sha512-LUewfj94xCMH2rbD5YJ+6AQ4AVjFYTgpp6rboWM5T7N3IsIF65SBEOVcYMGAEzO/kKNiNaW4LoWtoThOhH06gw==
+  dependencies:
+    "@octokit/openapi-types" "^16.0.0"
+
 "@pkgr/utils@^2.3.1":
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/@pkgr/utils/-/utils-2.3.1.tgz#0a9b06ffddee364d6642b3cd562ca76f55b34a03"
@@ -424,6 +525,11 @@ base64-js@^1.3.1:
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
 
+before-after-hook@^2.2.0:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-2.2.3.tgz#c51e809c81a4e354084422b9b26bad88249c517c"
+  integrity sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==
+
 bl@^4.0.3:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/bl/-/bl-4.1.0.tgz#451535264182bec2fbbc83a62ab98cf11d9f7b3a"
@@ -620,6 +726,11 @@ define-properties@^1.1.3, define-properties@^1.1.4:
   dependencies:
     has-property-descriptors "^1.0.0"
     object-keys "^1.1.1"
+
+deprecation@^2.0.0, deprecation@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/deprecation/-/deprecation-2.3.1.tgz#6368cbdb40abf3373b525ac87e4a260c3a700919"
+  integrity sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==
 
 detect-libc@^2.0.0, detect-libc@^2.0.1:
   version "2.0.1"
@@ -1415,6 +1526,11 @@ is-path-inside@^3.0.3:
   resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-3.0.3.tgz#d231362e53a07ff2b0e0ea7fed049161ffd16283"
   integrity sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==
 
+is-plain-object@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-5.0.0.tgz#4427f50ab3429e9025ea7d52e9043a9ef4159344"
+  integrity sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==
+
 is-regex@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.4.tgz#eef5663cd59fa4c0ae339505323df6854bb15958"
@@ -1691,6 +1807,13 @@ node-addon-api@^5.0.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-5.1.0.tgz#49da1ca055e109a23d537e9de43c09cca21eb762"
   integrity sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA==
+
+node-fetch@^2.6.7:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.9.tgz#7c7f744b5cc6eb5fd404e0c7a9fec630a55657e6"
+  integrity sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==
+  dependencies:
+    whatwg-url "^5.0.0"
 
 object-assign@^4.1.1:
   version "4.1.1"
@@ -2307,6 +2430,11 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
+
 tsconfig-paths@^3.14.1:
   version "3.14.1"
   resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz#ba0734599e8ea36c862798e920bcf163277b137a"
@@ -2377,6 +2505,11 @@ unbox-primitive@^1.0.2:
     has-symbols "^1.0.3"
     which-boxed-primitive "^1.0.2"
 
+universal-user-agent@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/universal-user-agent/-/universal-user-agent-6.0.0.tgz#3381f8503b251c0d9cd21bc1de939ec9df5480ee"
+  integrity sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==
+
 uri-js@^4.2.2:
   version "4.4.1"
   resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.4.1.tgz#9b1a52595225859e55f669d928f88c6c57f2a77e"
@@ -2388,6 +2521,19 @@ util-deprecate@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
+
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
+
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
 
 which-boxed-primitive@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
If you merge this, close #28

The link to the download page is automatically created using NextJS's SSR.
By adding revalidate, we enable ISR so that no request is sent to GitHub's API more than twice every 60 seconds.
If the app release is updated, it will be updated when someone views the download page.

I have checked the build behavior with Docker and it seems to be working well.